### PR TITLE
Add script.js for FAA document fetch

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,42 @@
+const FAA_DRS_API_KEY = "c480cd075825a9f44beab596ba0cada217476801";
+
+async function fetchDocs() {
+  const doctype = document.getElementById("doctype").value;
+  const url = `https://drs.faa.gov/api/drs/data-pull/${doctype}?offset=0&docLastModifiedDateSortOrder=DESC`;
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "x-api-key": FAA_DRS_API_KEY
+      }
+    });
+
+    const data = await response.json();
+    const resultsTable = document.getElementById("results");
+
+    resultsTable.innerHTML = `
+      <tr>
+        <th>Title</th>
+        <th>Last Modified</th>
+        <th>Download</th>
+      </tr>
+    `;
+
+    data.documents.forEach((doc) => {
+      resultsTable.innerHTML += `
+        <tr>
+          <td>${doc.title || doc.documentNumber || "Untitled"}</td>
+          <td>${doc.docLastModifiedDate || "—"}</td>
+          <td>
+            ${doc.mainDocumentDownloadURL
+              ? `<a href="${doc.mainDocumentDownloadURL}" target="_blank">Download</a>`
+              : "N/A"}
+          </td>
+        </tr>
+      `;
+    });
+  } catch (error) {
+    console.error("Error fetching documents:", error);
+    alert("Something went wrong. Check the console for details.");
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `script.js` with helper to fetch FAA documents

## Testing
- `git status --short`