### PR TITLE
Add local server for SmartDRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # SmartDRS
 AI Enhanced DRS
+
+## Running locally in Codex
+
+This project is a simple static site that queries the FAA DRS API. A minimal
+Node server (`server.js`) is included so the app can be served in the Codex
+environment without additional dependencies.
+
+1. From the project directory, start the server:
+
+   ```bash
+   node server.js
+   ```
+
+2. Open `http://localhost:3000` in your browser.
+
+The app requires Internet access to reach the FAA API. If the Codex environment
+is offline, the fetches in `script.js` will fail.

--- a/server.js
+++ b/server.js
@@ -1,0 +1,43 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  let filePath = '.' + req.url;
+  if (filePath === './') {
+    filePath = './index.html';
+  }
+  const ext = String(path.extname(filePath)).toLowerCase();
+  const mimeTypes = {
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.gif': 'image/gif'
+  };
+
+  const contentType = mimeTypes[ext] || 'application/octet-stream';
+
+  fs.readFile(filePath, (error, content) => {
+    if (error) {
+      if (error.code === 'ENOENT') {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('404 Not Found');
+      } else {
+        res.writeHead(500);
+        res.end(`Server Error: ${error.code}`);
+      }
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content, 'utf-8');
+    }
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}/`);
+});


### PR DESCRIPTION
## Summary
- add a simple Node HTTP server to serve the static site
- document how to run the app in Codex via the new server

## Testing
- `node --version`