### PR TITLE
Clarify project path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,15 @@ This project is a simple static site that queries the FAA DRS API. A minimal
 Node server (`server.js`) is included so the app can be served in the Codex
 environment without additional dependencies.
 
-1. From the project directory, start the server:
+1. From the project directory, start the server. Make sure your current working
+   directory is the repository root (typically `/workspace/SmartDRS` in Codex):
 
    ```bash
    node server.js
    ```
+
+   If you encounter an error like `Cannot find module '/workspaces/SmartDRS/server.js'`,
+   double-check that your path is `/workspace/SmartDRS` (note the missing `s`).
 
 2. Open `http://localhost:3000` in your browser.
 


### PR DESCRIPTION
## Summary
- clarify that `node server.js` must be run from `/workspace/SmartDRS`
- add note about the `Cannot find module` error when accidentally running from `/workspaces`

## Testing
- `node server.js`