### PR TITLE
Populate doc types dynamically

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,7 @@
 <body>
     <h1>FAA Document Viewer</h1>
     <label for="docType">Document Type:</label>
-    <select id="docType">
-        <option value="orders">Orders</option>
-        <option value="advisory-circular">Advisory Circulars</option>
-        <option value="handbooks">Handbooks</option>
-        <!-- Add more document types as needed -->
-    </select>
+    <select id="docType"></select>
     <button id="fetchBtn">Fetch Documents</button>
 
     <table border="1">
@@ -31,7 +26,42 @@
 <script>
 const FAA_DRS_API_KEY = "c480cd075825a9f44beab596ba0cada217476801";
 
+document.addEventListener('DOMContentLoaded', fetchDocTypes);
 document.getElementById('fetchBtn').addEventListener('click', fetchDocs);
+
+async function fetchDocTypes() {
+    const select = document.getElementById('docType');
+    select.innerHTML = '<option disabled selected>Loading...</option>';
+    try {
+        const response = await fetch('https://drs.faa.gov/api/doc-types', {
+            headers: {
+                'x-api-key': FAA_DRS_API_KEY
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+
+        const data = await response.json();
+        const types = data?.docTypes || data?.documentTypes || [];
+
+        select.innerHTML = '';
+        types.forEach(t => {
+            const option = document.createElement('option');
+            option.value = t.docType || t.code || t.id || t;
+            option.textContent = t.name || t.description || t.docType || t;
+            select.appendChild(option);
+        });
+    } catch (error) {
+        console.error('Error fetching document types:', error);
+        select.innerHTML = `
+            <option value="orders">Orders</option>
+            <option value="advisory-circular">Advisory Circulars</option>
+            <option value="handbooks">Handbooks</option>
+        `;
+    }
+}
 
 async function fetchDocs() {
     const docType = document.getElementById('docType').value;


### PR DESCRIPTION
## Summary
- automatically fetch available doc types from the DRS API on page load
- fall back to the original static list if fetching fails

## Testing
- `node server.js` *(fails: Server running at http://localhost:3000/)*