### PR TITLE
Fix fetchDocs API call

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ async function fetchDocTypes() {
 
 async function fetchDocs() {
     const docType = document.getElementById('docType').value;
-    const url = `https://drs.faa.gov/api/drs/data-pull/${docType}?offset=0`;
+    const url = `https://drs.faa.gov/api/drs/data-pull/${encodeURIComponent(docType)}?offset=0`;
 
     try {
         const response = await fetch(url, {

--- a/script.js
+++ b/script.js
@@ -1,8 +1,8 @@
 const FAA_DRS_API_KEY = "c480cd075825a9f44beab596ba0cada217476801";
 
 async function fetchDocs() {
-  const doctype = document.getElementById("doctype").value;
-  const url = `https://drs.faa.gov/api/drs/data-pull/${doctype}?offset=0&docLastModifiedDateSortOrder=DESC`;
+  const docType = document.getElementById("docType").value;
+  const url = `https://drs.faa.gov/api/drs/data-pull/${encodeURIComponent(docType)}?offset=0&docLastModifiedDateSortOrder=DESC`;
 
   try {
     const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- URL encode the docType when building the data-pull URL
- fix script.js to match docType element ID

## Testing
- `node -c script.js`
- `node -c server.js`
