### PR TITLE
Proxy doc types through local server

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,7 @@
 <body>
     <h1>FAA Document Viewer</h1>
     <label for="docType">Document Type:</label>
-    <select id="docType">
-        <option value="orders">Orders</option>
-        <option value="advisory-circular">Advisory Circulars</option>
-        <option value="handbooks">Handbooks</option>
-        <!-- Add more document types as needed -->
-    </select>
+    <select id="docType"></select>
     <button id="fetchBtn">Fetch Documents</button>
 
     <table border="1">
@@ -31,7 +26,43 @@
 <script>
 const FAA_DRS_API_KEY = "c480cd075825a9f44beab596ba0cada217476801";
 
+document.addEventListener('DOMContentLoaded', fetchDocTypes);
 document.getElementById('fetchBtn').addEventListener('click', fetchDocs);
+
+async function fetchDocTypes() {
+    const select = document.getElementById('docType');
+    select.innerHTML = '<option disabled selected>Loading...</option>';
+    try {
+        const response = await fetch('/api/doc-types');
+
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+
+        const data = await response.json();
+        const types = data?.docTypes || data?.documentTypes || [];
+
+        select.innerHTML = '';
+        types.forEach(t => {
+            const option = document.createElement('option');
+            option.value = t.docType || t.code || t.id || t;
+            option.textContent = t.name || t.description || t.docType || t;
+            select.appendChild(option);
+        });
+    } catch (error) {
+        console.error('Error fetching document types:', error);
+        select.innerHTML = `
+            <option value="orders">Orders</option>
+            <option value="advisory-circular">Advisory Circulars</option>
+            <option value="handbooks">Handbooks</option>
+            <option value="notices">Notices</option>
+            <option value="policy">Policy</option>
+            <option value="reports">Reports</option>
+            <option value="saib">SAIBs</option>
+            <option value="regulations">Regulations</option>
+        `;
+    }
+}
 
 async function fetchDocs() {
     const docType = document.getElementById('docType').value;

--- a/server.js
+++ b/server.js
@@ -2,9 +2,29 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 
+const FAA_DRS_API_KEY =
+  process.env.FAA_DRS_API_KEY || 'c480cd075825a9f44beab596ba0cada217476801';
+
 const port = process.env.PORT || 3000;
 
 const server = http.createServer((req, res) => {
+  if (req.url.startsWith('/api/doc-types')) {
+    fetch('https://drs.faa.gov/api/doc-types', {
+      headers: { 'x-api-key': FAA_DRS_API_KEY }
+    })
+      .then((apiRes) => apiRes.text())
+      .then((body) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(body);
+      })
+      .catch((err) => {
+        console.error('Error fetching doc types:', err);
+        res.writeHead(500);
+        res.end(JSON.stringify({ error: 'Failed to fetch doc types' }));
+      });
+    return;
+  }
+
   let filePath = '.' + req.url;
   if (filePath === './') {
     filePath = './index.html';


### PR DESCRIPTION
## Summary
- add proxy in `server.js` for `/api/doc-types`
- fetch doc types from the proxy in `index.html`
- expand fallback list with additional common types

## Testing
- `node server.js` *(server started successfully)*