### PR TITLE
Add proxy for doc types

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,7 @@
 <body>
     <h1>FAA Document Viewer</h1>
     <label for="docType">Document Type:</label>
-    <select id="docType">
-        <option value="orders">Orders</option>
-        <option value="advisory-circular">Advisory Circulars</option>
-        <option value="handbooks">Handbooks</option>
-        <!-- Add more document types as needed -->
-    </select>
+    <select id="docType"></select>
     <button id="fetchBtn">Fetch Documents</button>
 
     <table border="1">
@@ -31,11 +26,42 @@
 <script>
 const FAA_DRS_API_KEY = "c480cd075825a9f44beab596ba0cada217476801";
 
+document.addEventListener('DOMContentLoaded', fetchDocTypes);
 document.getElementById('fetchBtn').addEventListener('click', fetchDocs);
+
+async function fetchDocTypes() {
+    const select = document.getElementById('docType');
+    select.innerHTML = '<option disabled selected>Loading...</option>';
+    try {
+        const response = await fetch('/api/doc-types');
+
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+
+        const data = await response.json();
+        const types = data?.docTypes || data?.documentTypes || [];
+
+        select.innerHTML = '';
+        types.forEach(t => {
+            const option = document.createElement('option');
+            option.value = t.docType || t.code || t.id || t;
+            option.textContent = t.name || t.description || t.docType || t;
+            select.appendChild(option);
+        });
+    } catch (error) {
+        console.error('Error fetching document types:', error);
+        select.innerHTML = `
+            <option value="orders">Orders</option>
+            <option value="advisory-circular">Advisory Circulars</option>
+            <option value="handbooks">Handbooks</option>
+        `;
+    }
+}
 
 async function fetchDocs() {
     const docType = document.getElementById('docType').value;
-    const url = `https://drs.faa.gov/api/drs/data-pull/${docType}?offset=0`;
+    const url = `https://drs.faa.gov/api/drs/data-pull/${encodeURIComponent(docType)}?offset=0`;
 
     try {
         const response = await fetch(url, {

--- a/script.js
+++ b/script.js
@@ -1,8 +1,8 @@
 const FAA_DRS_API_KEY = "c480cd075825a9f44beab596ba0cada217476801";
 
 async function fetchDocs() {
-  const doctype = document.getElementById("doctype").value;
-  const url = `https://drs.faa.gov/api/drs/data-pull/${doctype}?offset=0&docLastModifiedDateSortOrder=DESC`;
+  const docType = document.getElementById("docType").value;
+  const url = `https://drs.faa.gov/api/drs/data-pull/${encodeURIComponent(docType)}?offset=0&docLastModifiedDateSortOrder=DESC`;
 
   try {
     const response = await fetch(url, {

--- a/server.js
+++ b/server.js
@@ -1,10 +1,43 @@
 const http = require('http');
+const https = require('https');
 const fs = require('fs');
 const path = require('path');
+
+// FAA API key is also hard coded in the frontend for this demo
+const FAA_DRS_API_KEY = 'c480cd075825a9f44beab596ba0cada217476801';
 
 const port = process.env.PORT || 3000;
 
 const server = http.createServer((req, res) => {
+  if (req.url === '/api/doc-types') {
+    const options = {
+      hostname: 'drs.faa.gov',
+      path: '/api/doc-types',
+      headers: { 'x-api-key': FAA_DRS_API_KEY }
+    };
+    https
+      .get(options, drsRes => {
+        let data = '';
+        drsRes.on('data', chunk => {
+          data += chunk;
+        });
+        drsRes.on('end', () => {
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*'
+          });
+          res.end(data);
+        });
+      })
+      .on('error', err => {
+        res.writeHead(500, {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*'
+        });
+        res.end(JSON.stringify({ error: err.message }));
+      });
+    return;
+  }
   let filePath = '.' + req.url;
   if (filePath === './') {
     filePath = './index.html';


### PR DESCRIPTION
## Summary
- merge main into work
- add `/api/doc-types` proxy in `server.js`
- fetch document types from the proxy instead of the FAA API directly

## Testing
- `node server.js` *(server started successfully)*