### PR TITLE
Populate doc types dynamically

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,7 @@
 <body>
     <h1>FAA Document Viewer</h1>
     <label for="docType">Document Type:</label>
-    <select id="docType">
-        <option value="orders">Orders</option>
-        <option value="advisory-circular">Advisory Circulars</option>
-        <option value="handbooks">Handbooks</option>
-        <!-- Add more document types as needed -->
-    </select>
+    <select id="docType"></select>
     <button id="fetchBtn">Fetch Documents</button>
 
     <table border="1">
@@ -31,7 +26,38 @@
 <script>
 const FAA_DRS_API_KEY = "c480cd075825a9f44beab596ba0cada217476801";
 
+document.addEventListener('DOMContentLoaded', fetchDocTypes);
 document.getElementById('fetchBtn').addEventListener('click', fetchDocs);
+
+async function fetchDocTypes() {
+    const select = document.getElementById('docType');
+    select.innerHTML = '<option disabled selected>Loading...</option>';
+    try {
+        const response = await fetch('/api/doc-types');
+
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+
+        const data = await response.json();
+        const types = data?.docTypes || data?.documentTypes || [];
+
+        select.innerHTML = '';
+        types.forEach(t => {
+            const option = document.createElement('option');
+            option.value = t.docType || t.code || t.id || t;
+            option.textContent = t.name || t.description || t.docType || t;
+            select.appendChild(option);
+        });
+    } catch (error) {
+        console.error('Error fetching document types:', error);
+        select.innerHTML = `
+            <option value="orders">Orders</option>
+            <option value="advisory-circular">Advisory Circulars</option>
+            <option value="handbooks">Handbooks</option>
+        `;
+    }
+}
 
 async function fetchDocs() {
     const docType = document.getElementById('docType').value;

--- a/script.js
+++ b/script.js
@@ -1,8 +1,10 @@
 const FAA_DRS_API_KEY = "c480cd075825a9f44beab596ba0cada217476801";
 
+document.addEventListener('DOMContentLoaded', fetchDocTypes);
+
 async function fetchDocs() {
-  const doctype = document.getElementById("doctype").value;
-  const url = `https://drs.faa.gov/api/drs/data-pull/${doctype}?offset=0&docLastModifiedDateSortOrder=DESC`;
+  const docType = document.getElementById("docType").value;
+  const url = `https://drs.faa.gov/api/drs/data-pull/${docType}?offset=0&docLastModifiedDateSortOrder=DESC`;
 
   try {
     const response = await fetch(url, {
@@ -38,5 +40,35 @@ async function fetchDocs() {
   } catch (error) {
     console.error("Error fetching documents:", error);
     alert("Something went wrong. Check the console for details.");
+  }
+}
+
+async function fetchDocTypes() {
+  const select = document.getElementById('docType');
+  select.innerHTML = '<option disabled selected>Loading...</option>';
+  try {
+    const response = await fetch('/api/doc-types');
+
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+
+    const data = await response.json();
+    const types = data?.docTypes || data?.documentTypes || [];
+
+    select.innerHTML = '';
+    types.forEach(t => {
+      const option = document.createElement('option');
+      option.value = t.docType || t.code || t.id || t;
+      option.textContent = t.name || t.description || t.docType || t;
+      select.appendChild(option);
+    });
+  } catch (error) {
+    console.error('Error fetching document types:', error);
+    select.innerHTML = `
+      <option value="orders">Orders</option>
+      <option value="advisory-circular">Advisory Circulars</option>
+      <option value="handbooks">Handbooks</option>
+    `;
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,10 +1,37 @@
 const http = require('http');
+const https = require('https');
 const fs = require('fs');
 const path = require('path');
+
+const FAA_DRS_API_KEY = 'c480cd075825a9f44beab596ba0cada217476801';
 
 const port = process.env.PORT || 3000;
 
 const server = http.createServer((req, res) => {
+  if (req.url === '/api/doc-types') {
+    const options = {
+      hostname: 'drs.faa.gov',
+      path: '/api/doc-types',
+      headers: {
+        'x-api-key': FAA_DRS_API_KEY
+      }
+    };
+
+    https.get(options, apiRes => {
+      let data = '';
+      apiRes.on('data', chunk => {
+        data += chunk;
+      });
+      apiRes.on('end', () => {
+        res.writeHead(apiRes.statusCode || 500, { 'Content-Type': 'application/json' });
+        res.end(data);
+      });
+    }).on('error', err => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Proxy request failed' }));
+    });
+    return;
+  }
   let filePath = '.' + req.url;
   if (filePath === './') {
     filePath = './index.html';


### PR DESCRIPTION
## Summary
- automatically fetch available doc types from the DRS API on page load
- fall back to the original static list if fetching fails
- proxy doc type requests through the Node server to avoid CORS issues

## Testing
- `node server.js`